### PR TITLE
Update sdk version for facebook ads

### DIFF
--- a/AdsHelper/build.gradle
+++ b/AdsHelper/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     // facebook ads library
-    implementation 'com.facebook.android:audience-network-sdk:6.5.0'
+    implementation 'com.facebook.android:audience-network-sdk:6.7.0'
     implementation 'androidx.annotation:annotation:1.2.0'
 
 }


### PR DESCRIPTION
update Facebook sdk
- com.facebook.android:audience-network-sdk:6.5.0 to com.facebook.android:audience-network-sdk:6.7.0
- release new library version for ads 
 implementation 'com.github.sofittech:AdsHelper-Android:1.0.7-facebook-only'
